### PR TITLE
Add feature: use web page content as context

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 // helper function that gets the contents of the current tab the user is on
 function getCurrentTabContent() {
     return new Promise((resolve, reject) => {
-        chrome.tabs.query({ active: true }, (tabs) => {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
             if (chrome.runtime.lastError) {
                 return reject(chrome.runtime.lastError);
             }

--- a/content.js
+++ b/content.js
@@ -1,0 +1,5 @@
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+  if (request.method == "getContent"){
+    sendResponse({data: document.body.innerText, method: "getContent"}); 
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
     "permissions": [
         "storage",
         "tabs",
-        "activeTab",
+        "activeTab"
     ],
     "background": {
         "service_worker": "background.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "OpenAI ChatGPT Chrome Extension",
-    "version": "2.0",
-    "description": "Have a seamless ChatGPT experience, without ever leaving your favorite website.",
+    "version": "2.1.0",
+    "description": "Have a seamless ChatGPT experience, using webpage as context.",
     "default_locale": "en",
     "icons": {
         "16": "assets/icons/icon-16.png",
@@ -12,11 +12,19 @@
         "https://api.openai.com/v1/completions"
     ],
     "permissions": [
-        "storage"
+        "storage",
+        "tabs",
+        "activeTab",
     ],
     "background": {
         "service_worker": "background.js"
     },
+    "content_scripts": [
+        {
+            "matches": ["<all_urls>"],
+            "js": ["content.js"]
+        }
+    ],
     "action": {
         "default_popup": "popup/popup.html"
     },

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -16,9 +16,6 @@ document.addEventListener('DOMContentLoaded', function () {
         const chatHistory = result.chatHistory || [];
 
         if (chatHistory.length > 0) {
-            // hide the system message
-            chatHistory.shift();
-
             // display the chat history
             displayMessages(chatHistory);
 
@@ -182,9 +179,11 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Function to display an array of messages
-    function displayMessages(messages) {
+    function displayMessages(messages, displaySystemMessages = false) {
         for (const message of messages) {
+            if (message.role !== 'system' || displaySystemMessages) {
             displayMessage(message.role, message.content);
+            }
         }
     }
 


### PR DESCRIPTION
Function: Now, gpt can get the content of the webpage and answer accordingly.

Changes:
- Use `content.js` to get text of body on request
- Add these text in system prompts

Known bug:
If the text of body is too long, the chat history and thereby the message sent to the api server will exceed the length limit. This bug can be fixed with an abstraction function, which can also be used for long chat history. I leave this bug to next version.